### PR TITLE
Add CI checks that test fontproof templates in SILE

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -3,18 +3,17 @@ name: Luacheck
 on: [push, pull_request]
 
 jobs:
+
   luacheck:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Setup Lua
-      uses: leafo/gh-actions-lua@v5
-      with:
-        luaVersion: 5.3
-    - name: Setup Lua Rocks
-      uses: leafo/gh-actions-luarocks@v2
-    - name: Instalal luacheck
+      uses: leafo/gh-actions-lua@v7
+    - name: Setup LuaRocks
+      uses: leafo/gh-actions-luarocks@v3
+    - name: Install luacheck
       run: luarocks install luacheck
     - name: Lint all the Lua code
       run: luacheck .

--- a/.github/workflows/sile.yml
+++ b/.github/workflows/sile.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sileVersion: ["v0.10.10", "v0.10.11"]
+        sileVersion: ["v0.10.11", "v0.10.12"]
     runs-on: ubuntu-latest
     container:
       image: docker://siletypesetter/sile:${{ matrix.sileVersion }}

--- a/.github/workflows/sile.yml
+++ b/.github/workflows/sile.yml
@@ -1,0 +1,26 @@
+name: SILE
+
+on: [push, pull_request]
+
+jobs:
+
+  sile:
+    strategy:
+      fail-fast: false
+      matrix:
+        sileVersion: ["v0.10.10", "v0.10.11"]
+    runs-on: ubuntu-latest
+    container:
+      image: docker://siletypesetter/sile:${{ matrix.sileVersion }}
+      options: --entrypoint=bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run test template
+      run: sile fpTest.sil
+    - name: Run gutenberg template
+      run: sile fpGutenberg.sil
+    - name: Run unichar template
+      run: sile fpUnichar.sil
+    - name: Run full template
+      run: sile fpFull.sil

--- a/.github/workflows/sile.yml
+++ b/.github/workflows/sile.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Install dictionary
+      run: pacman --noconfirm -S words
     - name: Run test template
       run: sile fpTest.sil
     - name: Run gutenberg template

--- a/.github/workflows/sile.yml
+++ b/.github/workflows/sile.yml
@@ -24,3 +24,8 @@ jobs:
       run: sile fpUnichar.sil
     - name: Run full template
       run: sile fpFull.sil
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: fp-templates.zip
+        path: fp*.pdf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FontProof - a font design testing class for SILE
 
-[![Luacheck Lint Status](https://img.shields.io/github/workflow/status/silnrsi/fontproof/Luacheck?label=Luacheck&logo=Github)](https://github.com/silnrsi/fontproof/actions?workflow=Luacheck)
+[![Luacheck Lint Status](https://img.shields.io/github/workflow/status/sile-typesetter/fontproof/Luacheck?label=Luacheck&logo=Github)](https://github.com/sile-typesetter/fontproof/actions?workflow=Luacheck)
+[![SILE Render Status](https://img.shields.io/github/workflow/status/sile-typesetter/fontproof/SILE?label=SILE&logo=Github)](https://github.com/sile-typesetter/fontproof/actions?workflow=SILE)
 
 FontProof enables you to produce PDF font test documents without fiddling with InDesign or other manual page layout or word processing programs. You can apply one of the predesigned test documents (to be added later) or use FontProof to build your own custom font test document.
 


### PR DESCRIPTION
SILE itself is pretty easy to run from GitHub Actions now. Here is a workflow with jobs to test run all the templates in fontproof using the latest two releases of SILE.