### PR TITLE
Setup Docker container with SILE + Fontproof and make it possible to run as a GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v2.1.0
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: docker.pkg.github.com
+          repository: sile-typesetter/sile/fontproof
+          tag_with_ref: true

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,18 @@
+name: Versioning
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+
+  actions-tagger:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+        with:
+          publish_latest_tag: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM docker.io/siletypesetter/sile:v0.10.12 AS fontproof
 
+# This is a hack to convince Docker Hub that its cache is behind the times.
+# This happens when the contents of our dependencies changes but the base
+# system hasn't been refreshed. It's helpful to have this as a separate layer
+# because it saves a lot of time for local builds, but it does periodically
+# need a poke. Incrementing this when changing dependencies or just when the
+# remote Docker Hub builds die should be enough.
+ARG DOCKER_HUB_CACHE=1
+
 # Freshen all base system packages
 RUN pacman --needed --noconfirm -Syuq && yes | pacman -Sccq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM docker.io/siletypesetter/sile:v0.10.12 AS fontproof
+
+# Freshen all base system packages
+RUN pacman --needed --noconfirm -Syuq && yes | pacman -Sccq
+
+# Install fontproof dependencies
+RUN pacman --needed --noconfirm -Syq words
+
+# Set at build time, forces Docker's layer caching to reset at this point
+ARG VCS_REF=0
+
+# Copy fontproof sources somewhere
+COPY ./ /usr/local/share/fontproof
+
+# Patch SILE path with our quazi-installation directory
+RUN sed -i -e '/^extendPath...../a extendPath("/usr/local/share/fontproof")' \
+	/usr/local/bin/sile
+
+LABEL maintainer="Caleb Maclennan <caleb@alerque.com>"
+LABEL version="$VCS_REF"
+
+RUN sile --version
+
+WORKDIR /data
+ENTRYPOINT ["sile"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+VERSION := $(shell git describe --long --tags --always)
+
+.PHONY: docker
+docker: Dockerfile
+	docker build \
+		--build-arg VCS_REF="$(VERSION)" \
+		--tag siletypesetter/fontproof:HEAD \
+		./

--- a/README.md
+++ b/README.md
@@ -57,17 +57,50 @@ At this point there is one main template - _fpFull.sil_ - but more will follow. 
 
 ## Docker usage
 
-As an alternative method to install and use FontProof, a Docker image is avalable with SILE and the fontproof class baked in.
+As an alternative method to install and use FontProof, a [Docker image](https://hub.docker.com/repository/docker/siletypesetter/fontproof) is avalable with SILE and the *fontproof* class baked in and ready for use.
+Released versions are tagged to match (e.g. `v.1.3.4`), the latest release will be tagged `latest`, and a `master` tag is also available with the freshest development build.
+In order to be useful you need to tell the Docker run command a way to reach your source documents (and hence also to give it a place to write the output) as well as tell it who you are on the host machine so the output generated inside the container can be created with the expected ownership properties.
+You may find it easiest to run with an alias like this:
 
 ```console
 $ alias fontproof='docker run -it --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/fontproof:latest'
-$ fontproof input.sil
+$ fontproof proofs.sil
 ```
 
-## Remote usage as GitHub Action
+## Remote usage
 
-FontProof can be executed as a GitHub Action on a remote repository.
-Actually any CI runner that can use Docker images as runners would work, but here is how to use it for Actions:
+Any remote CI system that can use Docker images as job runners could be configured to run FontProof jobs.
+Additionally a ready-made GitHub Action is [available on the marketplace](https://github.com/marketplace/actions/fontproof):
+
+```yaml
+name: FontProof
+on: [push, pull_request]
+jobs:
+  fontproof:
+    runs-on: ubuntu-latest
+    name: FontProof
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: FontProof
+        id: fontproof
+        uses: docker://siletypesetter/fontproof:latest
+        with:
+          args: proofs.sil
+```
+
+Add to your repository as `.github/workflows/fontproof.yaml`.
+This work flow assumes your project has a source file `proofs.sil` and will leave behind a `proofs.pdf`.
+Note that this Actions work flow explicitly uses a container fetched from Docker Hub because this is the fastest way to get rolling, and the comments in [the section about Docker](#docker-usage) regarding tagged versions besides `latest` apply equally here.
+
+Because this repository is itself a GitHub Action you can also use the standard `uses` syntax like this:
+
+```yaml
+        uses: sile-typesetter/fontproof@latest
+```
+
+But be warned that since GitHub rebuilds containers from scratch on every such invocation, this syntax is not recommended for regular use.
+
 
 ## Adding or modifying tests
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ _(Note: In earlier versions of fontproof this was `-f` or `-p`, however this a s
 
 At this point there is one main template - _fpFull.sil_ - but more will follow. That template will show you almost all that FontProof can do. SILE itself is capable of far, far, more, and you're very welcome to play around with it.
 
+## Docker usage
+
+As an alternative method to install and use FontProof, a Docker image is avalable with SILE and the fontproof class baked in.
+
+```console
+$ alias fontproof='docker run -it --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/fontproof:latest'
+$ fontproof input.sil
+```
+
+## Remote usage as GitHub Action
+
+FontProof can be executed as a GitHub Action on a remote repository.
+Actually any CI runner that can use Docker images as runners would work, but here is how to use it for Actions:
+
 ## Adding or modifying tests
 
 Each template can contain a full selection of tests. Each test is specified using a command in this general format:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,8 @@
+name: FontProof
+description: A font design testing class for SILE
+runs:
+  using: docker
+  image: Dockerfile
+branding:
+  icon: book-open
+  color: cyan


### PR DESCRIPTION
This PR:

- [x] Adds a `Dockerfile` that takes the Docker container for SILE as a base and adds in fontproof. The method is a little unorthodox, but I expect the current SILE package system to get replaced and it isn't very useful for this purpose because we want to match versions of fontproof with Docker containers of the same version so that downstream project cat get repeatable results with their preferred version of fontproof.

- [x] Adds a `Makefile` that is purely developer convenience, and is mostly useful for building a Docker image locally. Most people will probably full a prebuilt one from docker.io, but for testing it's handy to be able to run `make docker`.

- [x] Configures this repository so it can be used *as* a GitHub Action. This will make it trivially easy for font project repositories to setup CI workflows that test their font projects using Fontproof.

If you are interested in this, I'll need a couple things to be done by somebody at SIL.

- [x] Setup an org at Docker Hub and either configure it to build containers from this repository. I can provide exact instructions or add my user with permissions to set it up.

- [x] Update the generated image name and documentation with whatever was actually used to register, I've just filled in a guess right now (`silnrsi/fontproof`).

- [x] Change maintainer info in the Dockerfile to whoever is responsible for the Docker Hub registry.

Additional tidbits that could be done to round this out:

- [x] Document how to use it as a GitHub Action from a font project repository.

- [x] Document how to run a specific version (HEAD vs. latest vs. any tagged version).