### PR TITLE
Bump Docker builds and CI matrix to latest SILE‌ release

### DIFF
--- a/.github/workflows/sile.yml
+++ b/.github/workflows/sile.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sileVersion: ["v0.10.11", "v0.10.12", "v0.10.13"]
+        sileVersion: ["v0.10.11", "v0.10.13", "v0.10.15"]
     runs-on: ubuntu-latest
     container:
       image: docker://siletypesetter/sile:${{ matrix.sileVersion }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/siletypesetter/sile:v0.10.13 AS fontproof
+FROM docker.io/siletypesetter/sile:v0.10.15 AS fontproof
 
 # This is a hack to convince Docker Hub that its cache is behind the times.
 # This happens when the contents of our dependencies changes but the base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM docker.io/siletypesetter/sile:v0.10.15 AS fontproof
+#syntax=docker/dockerfile:1.2
+
+ARG SILETAG
+
+FROM docker.io/siletypesetter/sile:$SILETAG AS fontproof
 
 # This is a hack to convince Docker Hub that its cache is behind the times.
 # This happens when the contents of our dependencies changes but the base
-# system hasn't been refreshed. It's helpful to have this as a separate layer
+# system hasn’t been refreshed. It’s helpful to have this as a separate layer
 # because it saves a lot of time for local builds, but it does periodically
 # need a poke. Incrementing this when changing dependencies or just when the
 # remote Docker Hub builds die should be enough.
 ARG DOCKER_HUB_CACHE=0
 
+ARG RUNTIME_DEPS
 # Freshen all base system packages
 RUN pacman --needed --noconfirm -Syuq && yes | pacman -Sccq
 
-# Install fontproof dependencies
-RUN pacman --needed --noconfirm -Syq words && yes | pacman -Sccq
+# Install run-time dependecies (increment cache var above)
+RUN pacman --needed --noconfirm -Sq $RUNTIME_DEPS && yes | pacman -Sccq
 
-# Set at build time, forces Docker's layer caching to reset at this point
+# Set at build time, forces Docker’s layer caching to reset at this point
 ARG VCS_REF=0
 
 # Copy fontproof sources somewhere

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,4 @@ VERSION := $(shell git describe --long --tags --always)
 
 .PHONY: docker
 docker: Dockerfile
-	docker build \
-		--build-arg VCS_REF="$(VERSION)" \
-		--tag siletypesetter/fontproof:HEAD \
-		./
+	IMAGE_NAME=siletypesetter/fontproof:HEAD ./hooks/build $(VERSION)

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -e
+
+: "${SILETAG:=v0.10.15}"
+
+DESC=$(git describe --long --tags --always)
+
+RUNTIME_DEPS='words'
+
+: "${DOCKER_BUILDKIT:=1}"
+export DOCKER_BUILDKIT
+
+docker build \
+	--build-arg SILETAG="$SILETAG" \
+	--build-arg VCS_REF="${1:-$DESC}" \
+	--build-arg RUNTIME_DEPS="$RUNTIME_DEPS" \
+	--tag $IMAGE_NAME \
+	./


### PR DESCRIPTION
- Add SILE v0.10.15 to CI test matrix and drop v0.10.12
- Update base Docker image to build on SILE v0.10.15
- Overhaul Docker build to be more modular and use BuildKit
