### PR TITLE
Fixup font option handling between CLI & templates

### DIFF
--- a/classes/fontproof/init.lua
+++ b/classes/fontproof/init.lua
@@ -147,7 +147,7 @@ function class:registerCommands ()
   plain.registerCommands(self)
 
   self:registerCommand("setTestFont", function (options, _)
-    _scratch.testfont = options
+    _scratch.testfont = pl.tablex.merge(_scratch.testfont, options, true)
     SILE.call("font", options)
   end)
 

--- a/classes/fontproof/init.lua
+++ b/classes/fontproof/init.lua
@@ -85,10 +85,11 @@ function class:_init (options)
     groups = {}
   }
 
-  -- luacheck: ignore _fpFilename _fpFamily _fpSize
+  -- luacheck: ignore _fpFilename _fpFamily _fpSize _fpFeatures
   _scratch.testfont.filename = (options.filename and options.filename) or (_fpFilename and _fpFilename) or nil
   _scratch.testfont.family = (options.family and options.family) or (_fpFamily and _fpFamily) or "Gentium Plus"
   _scratch.testfont.size = (options.size and options.size) or (_fpSize and _fpSize) or "8pt"
+  _scratch.testfont.features = (options.features and options.features) or (_fpFeatures and _fpFeatures) or nil
   SILE.call("font", _scratch.testfont)
 
   _scratch.runhead.family = "Gentium Plus"
@@ -120,9 +121,9 @@ function class:endPage ()
   SILE.call("nofolios")
   local fontinfo
   if _scratch.testfont.filename then
-    fontinfo = ("Font file: %s"):format(_scratch.testfont.filename)
+    fontinfo = ("Font file: %s %s"):format(_scratch.testfont.filename, _scratch.testfont.features)
   else
-    fontinfo = ("Font family: %s"):format(_scratch.testfont.family)
+    fontinfo = ("Font family: %s %s"):format(_scratch.testfont.family, _scratch.testfont.features)
   end
   local templateinfo = ("Template file: %s.sil"):format(SILE.masterFilename)
   local dateinfo = os.date("%A %d %b %Y %X %z %Z")
@@ -147,8 +148,8 @@ function class:registerCommands ()
   plain.registerCommands(self)
 
   self:registerCommand("setTestFont", function (options, _)
-    _scratch.testfont = pl.tablex.merge(_scratch.testfont, options, true)
-    SILE.call("font", options)
+    _scratch.testfont = pl.tablex.merge(options, _scratch.testfont, true)
+    SILE.call("font", _scratch.testfont)
   end)
 
   -- optional way to override defaults

--- a/classes/fontproof/init.lua
+++ b/classes/fontproof/init.lua
@@ -1,6 +1,8 @@
 -- Copyright (C) 2016-2023 SIL International
 -- SPDX-License-Identifier: MIT
 
+local hb = require("justenoughharfbuzz")
+
 local plain = require("classes.plain")
 local class = pl.class(plain)
 class._name = "fontproof"
@@ -95,10 +97,6 @@ function class:_init (options)
   _scratch.section.size = "12pt"
   _scratch.subsection.family = "Gentium Plus"
   _scratch.subsection.size = "12pt"
-  _scratch.sileversion = SILE.version
-
-  local hb = require("justenoughharfbuzz")
-  _scratch.hb = hb.version()
 
   plain._init(self, options)
 
@@ -120,12 +118,17 @@ end
 
 function class:endPage ()
   SILE.call("nofolios")
-  local runheadinfo
+  local fontinfo
   if _scratch.testfont.filename then
-    runheadinfo = "Fontproof for: " .. _scratch.testfont.filename .. " - Input file: " ..  SILE.masterFilename .. ".sil - " .. os.date("%A %d %b %Y %X %z %Z") .. " - SILE " .. _scratch.sileversion .. " - HarfBuzz " ..  _scratch.hb
+    fontinfo = ("Font file: %s"):format(_scratch.testfont.filename)
   else
-    runheadinfo = "Fontproof for: " .. _scratch.testfont.family .. " - Input file: " .. SILE.masterFilename .. ".sil - " .. os.date("%A %d %b %Y %X %z %Z") .. " - SILE " .. _scratch.sileversion .. " - HarfBuzz " ..  _scratch.hb
+    fontinfo = ("Font family: %s"):format(_scratch.testfont.family)
   end
+  local templateinfo = ("Template file: %s.sil"):format(SILE.masterFilename)
+  local dateinfo = os.date("%A %d %b %Y %X %z %Z")
+  local sileinfo = ("SILE %s"):format(SILE.version)
+  local harfbuzzinfo = ("HarfBuzz %s"):format(hb.version())
+  local runheadinfo = ("Fontproof for: %s - %s - %s - %s - %s"):format(fontinfo, templateinfo, dateinfo, sileinfo, harfbuzzinfo)
   SILE.typesetNaturally(SILE.getFrame("runningHead"), function()
     SILE.settings:set("document.rskip", SILE.nodefactory.hfillglue())
     SILE.settings:set("typesetter.parfillskip", SILE.nodefactory.glue(0))

--- a/src/fontproof.lua
+++ b/src/fontproof.lua
@@ -19,7 +19,8 @@ cliargs:set_description([[
 cliargs:option("-f, --filename=VALUE", "Specify the font to be tested as a path to a font file")
 cliargs:option("-F, --family=VALUE", "Specify the font to be tested as a family name")
 cliargs:option("-o, --output=FILE", "output file name")
-cliargs:option("-s, --size=VALUE", "Specify the default test font size")
+cliargs:option("-p, --features=VALUE", "Specify the test font features")
+cliargs:option("-s, --size=VALUE", "Specify the test font size")
 cliargs:option("-t, --template=VALUE", "Use the bundled template by name (full, gutenberg, test, unichar);")
 cliargs:flag("-h, --help", "display this help, then exit")
 cliargs:flag("-v, --version", "display version information, then exit", print_version)
@@ -38,10 +39,11 @@ local size = opts.size and ("-e '_fpSize=\"%s\"'"):format(opts.size) or ""
 local template = opts.template and ("templates/%s.sil"):format(opts.template) or ""
 local family = opts.family and ("-e '_fpFamily=\"%s\"'"):format(opts.family) or ""
 local output = ("-o %s"):format(opts.output or "fontproof.pdf")
+local features = opts.features and ("-e '_fpFeatures=\"%s\"'"):format(opts.features) or ""
 local args = opts.SILEARGS and table.concat(opts.SILEARGS, " ") or ""
 
 local _, status, signal =
-   os.execute(table.concat({"sile", filename, family, size, template, output, args}, " "))
+   os.execute(table.concat({"sile", filename, family, size, features, template, output, args}, " "))
 
 if status == "exit" then
    os.exit(signal)


### PR DESCRIPTION
Closes #39

* Merges various font options whether passed from CLI or inside a template rather than one clobbering the other
* Doesn't die trying to format strings that don't exist (e.g. font family if specified by filename and visa versa)
* Adds a CLI flag to pass OpenType options from the CLI for quick tests without updating templates
